### PR TITLE
Update ariel.py

### DIFF
--- a/ariel.py
+++ b/ariel.py
@@ -136,7 +136,7 @@ ariel.addParams({
     "maxissuepercycle" : 3,
     "maxtranscore": 16,
     "pipetimeout" : 0,
-    "corecount" : groups * cores_per_group,
+    "corecount" : groups * cores_per_group/2,
     "memorylevels" : 1,
     "pagecount0" : num_pages,
     "pagesize0" : page_size * 1024,


### PR DESCRIPTION
I think you should have half the core counts instantiated by Ariel, as the other half is used for MMU instances to be connected through dummy caches to the LLC. Using pthreads seems to run some of the threads on the unattached Ariel Cores, thus sending requests to NULL (not connected) links causing a seg fault.